### PR TITLE
Support remote resolving of streams (e.g. via web interfaces)

### DIFF
--- a/xstream.py
+++ b/xstream.py
@@ -159,6 +159,16 @@ def parseUrl():
             updateManager.xStreamUpdate()
             updateManager.urlResolverUpdate()
             return
+    elif params.exist('remoteplayurl'):
+       import urlresolver
+       oGui = cGui()
+       remotePlayUrl = params.getValue('remoteplayurl')
+       sLink = urlresolver.resolve(remotePlayUrl)
+       if isinstance(sLink, basestring):
+         xbmc.executebuiltin( "PlayMedia(" + sLink + ")" )
+       else:
+         logger.info("Could not play remote url '%s'" % (sLink))
+       return         
     else:
       sFunction = 'load'
 

--- a/xstream.py
+++ b/xstream.py
@@ -160,15 +160,17 @@ def parseUrl():
             updateManager.urlResolverUpdate()
             return
     elif params.exist('remoteplayurl'):
-       import urlresolver
-       oGui = cGui()
-       remotePlayUrl = params.getValue('remoteplayurl')
-       sLink = urlresolver.resolve(remotePlayUrl)
-       if isinstance(sLink, basestring):
-         xbmc.executebuiltin( "PlayMedia(" + sLink + ")" )
-       else:
-         logger.info("Could not play remote url '%s'" % (sLink))
-       return         
+        try:
+            import urlresolver
+            remotePlayUrl = params.getValue('remoteplayurl')
+            sLink = urlresolver.resolve(remotePlayUrl)
+            if sLink:
+                xbmc.executebuiltin( "PlayMedia(" + sLink + ")" )
+            else:
+                logger.info("Could not play remote url '%s'" % (sLink))
+        except urlresolver.resolver.ResolverError as e:
+	        logger.info('ResolverError: %s' % e)
+        return         
     else:
       sFunction = 'load'
 


### PR DESCRIPTION
With this pull request xstream can be called with any stream url supported by urlresolver plugin. 

I use it for my web interface, where i can paste a stream url to play it on any Kodi Host in my environment. 

Hopefully others find this useful and it will be integrated.

JavaScript usage example:

```
var url = $('#remoteplayurl').val(); // e.g. http://...streamcloud.../asdfasdf
var requestData = '{"jsonrpc": "2.0","method": "Addons.ExecuteAddon","params": {"addonid": "plugin.video.xstream","params": {"remoteplayurl": "'+ url + '"}},"id": "2"}';

$.ajax({
        contentType: 'application/json',
        data: requestData,
        dataType: 'json',
        success: function(data){
            console.log('ok, remote device is playing requested url')
        },
        error: function(){
              console.log('failed to play url')
        },
        processData: false,
        type: 'POST',
        url: '/jsonrpc'
});

```